### PR TITLE
maxBulkSize and maxBsonSize should be lazy

### DIFF
--- a/bson/src/main/scala/dao/BsonDao.scala
+++ b/bson/src/main/scala/dao/BsonDao.scala
@@ -157,7 +157,7 @@ abstract class BsonDao[Model, ID](db: => DB, collectionName: String)(implicit mo
     }
   }
 
-  private val (maxBulkSize, maxBsonSize): (Int, Int) =
+  private lazy val (maxBulkSize, maxBsonSize): (Int, Int) =
     collection.db.connection.metadata.map {
       metadata => metadata.maxBulkSize -> metadata.maxBsonSize
     }.getOrElse[(Int, Int)](Int.MaxValue -> Int.MaxValue)
@@ -171,7 +171,7 @@ abstract class BsonDao[Model, ID](db: => DB, collectionName: String)(implicit mo
 
     collection.bulkInsert(mappedDocuments.map(writer.write(_)).toStream,
       true, defaultWriteConcern, bulkSize, bulkByteSize) map { result =>
-        mappedDocuments.map(lifeCycle.postPersist)
+        mappedDocuments.foreach(lifeCycle.postPersist)
         result.n
       }
   }

--- a/json/src/main/scala/dao/JsonDao.scala
+++ b/json/src/main/scala/dao/JsonDao.scala
@@ -163,7 +163,7 @@ abstract class JsonDao[Model: OFormat, ID: Writes](db: => DB, collectionName: St
     }
   }
 
-  private val (maxBulkSize, maxBsonSize): (Int, Int) =
+  private lazy val (maxBulkSize, maxBsonSize): (Int, Int) =
     collection.db.connection.metadata.map {
       metadata => metadata.maxBulkSize -> metadata.maxBsonSize
     }.getOrElse[(Int, Int)](Int.MaxValue -> Int.MaxValue)
@@ -182,7 +182,7 @@ abstract class JsonDao[Model: OFormat, ID: Writes](db: => DB, collectionName: St
 
     collection.bulkInsert(go(mappedDocuments.toTraversable),
       true, defaultWriteConcern, bulkSize, bulkByteSize) map { result =>
-        mappedDocuments.map(lifeCycle.postPersist)
+        mappedDocuments.foreach(lifeCycle.postPersist)
         result.n
       }
   }


### PR DESCRIPTION
It should be possible to make `db` lazy (since it's called by name) and this seems to be the only eager usage in DAOs.